### PR TITLE
Fix empty Array check and map => forEach

### DIFF
--- a/lib/services/user.js
+++ b/lib/services/user.js
@@ -313,8 +313,8 @@ module.exports = class UserService extends Schmervice.Service {
           .offset(offset)
           .withGraphFetched('[registrations, classes, classes.[facilitator],partner]');
       }
-      _.map(students, (inner) => {
-        if (inner.partner !== [] && inner.partner !== null) {
+      _.forEach(students, (inner) => {
+        if (inner.partner !== null && inner.partner.length > 0) {
           // eslint-disable-next-line
           inner.partner = inner.partner[0];
         } else {


### PR DESCRIPTION
* `inner.partner !== []` will always evaluate to `true` in JavaScript (`[] !== []` is `true`; see https://github.com/navgurukul/sansaar/pull/483#discussion_r777098799)
* `forEach` should be used instead of `map` here so you don't unnecessarily create an Array of `undefined`.