### PR TITLE
Performance optimization: Count of partner students

### DIFF
--- a/lib/services/display.js
+++ b/lib/services/display.js
@@ -460,18 +460,23 @@ module.exports = class DisplayService extends Schmervice.Service {
 
   transformPartnersData = async (partners) => {
     const { UserRole } = this.server.models();
-    let usersData = 0;
-    for (let singlePartnerData of partners){
-      for (let singleUserData of singlePartnerData.users){
-        let user = await UserRole.query().where('user_id', singleUserData.id)
-        if (user.length <= 0){
-          usersData += 1;
-        }
-      }
-      singlePartnerData.user = usersData;
-      usersData = 0;
+    // Set of ids of users having roles
+    // Partners' ids seem to be being converted to strings so we convert
+    //   ids to strings for comparison,
+    //   may be related to https://stackoverflow.com/a/54182813
+    const roleUserIds = new Set(
+      await UserRole.query()
+        .select('user_id')
+        .then((users) => users.map((user) => user.user_id.toString()))
+    );
+
+    for (let singlePartnerData of partners) {
+      singlePartnerData.user = singlePartnerData.users.filter(
+        (user) => !roleUserIds.has(user.id.toString())
+      ).length;
       delete singlePartnerData.users;
     }
+
     return partners;
   };
 };


### PR DESCRIPTION
* Only queries the `UserRole` table once instead of once for each user associated with each partner. 
* Stores all user ids of users having at least one role in a `Set`, which means we get fast lookup time for determining whether a given user has any role (`O(1)`). Consequently, counting the number of students from the `S` users of a partner can be done in `O(S)` time.