### PR TITLE
fix: module average percentage

### DIFF
--- a/lib/services/exercisesV2.js
+++ b/lib/services/exercisesV2.js
@@ -290,7 +290,7 @@ module.exports = class ExercisesServiceV2 extends Schmervice.Service {
                 }
                 count += 1;
               }
-              const avg = Math.floor((sum / (count * 100)) * 100);
+              const avg = Math.floor(sum / count);
 
               let existsModule;
 
@@ -423,7 +423,7 @@ module.exports = class ExercisesServiceV2 extends Schmervice.Service {
                 }
                 count += 1;
               }
-              const avg = Math.floor((sum / (count * 100)) * 100);
+              const avg = Math.floor(sum / count);
 
               let existspathway;
               let completedPathway;
@@ -551,7 +551,7 @@ module.exports = class ExercisesServiceV2 extends Schmervice.Service {
               }
               count += 1;
             }
-            const avg = Math.floor((sum / (count * 100)) * 100);
+            const avg = Math.floor(sum / count);
 
             let existsModule;
 
@@ -611,7 +611,7 @@ module.exports = class ExercisesServiceV2 extends Schmervice.Service {
                   }
                   mduleCount += 1;
                 }
-                const moduleAvg = Math.floor((moduleSum / (mduleCount * 100)) * 100);
+                const moduleAvg = Math.floor(moduleSum / mduleCount);
                 let existspathway;
 
                 let completedPathway;
@@ -680,7 +680,7 @@ module.exports = class ExercisesServiceV2 extends Schmervice.Service {
                 }
                 count += 1;
               }
-              const avg = Math.floor((sum / (count * 100)) * 100);
+              const avg = Math.floor(sum / count);
 
               let existspathway;
               let completedPathway;
@@ -801,7 +801,7 @@ module.exports = class ExercisesServiceV2 extends Schmervice.Service {
               }
               mduleCount += 1;
             }
-            const moduleAvg = Math.floor((moduleSum / (mduleCount * 100)) * 100);
+            const moduleAvg = Math.floor(moduleSum / mduleCount);
 
             let existspathway;
 

--- a/lib/services/exercisesV2.js
+++ b/lib/services/exercisesV2.js
@@ -355,7 +355,7 @@ module.exports = class ExercisesServiceV2 extends Schmervice.Service {
                     }
                     mduleCount += 1;
                   }
-                  const moduleAvg = Math.floor((moduleSum / (mduleCount * 100)) * 100);
+                  const moduleAvg = Math.floor(moduleSum / mduleCount);
                   let existspathway;
 
                   let completedPathway;


### PR DESCRIPTION
Mathematically, `(moduleSum / (mduleCount * 100)) * 100 = moduleSum/mduleCount`. However, due to rounding errors, this won't necessarily be the case. For example, if `moduleSum = 114` and `mduleCount = 2`, then `Math.floor((moduleSum / (mduleCount * 100)) * 100)` will evaluate to `56` instead of the correct `114/2 = 57`.