### PR TITLE
allow slug_id to insert into db for the pre-quiz also

### DIFF
--- a/lib/services/assessment.js
+++ b/lib/services/assessment.js
@@ -583,7 +583,7 @@ module.exports = class AssessmentService extends Schmervice.Service {
   async validateSlug(slug_id, course_id) {
     try {
       const { data } = await strapi.findOne('slugs', slug_id, {
-        populate: ['course', 'assessments', 'assessments.option'],
+        populate: ['course', 'assessments', 'assessments.option', 'prequizs', 'prequizs.option'],
       });
 
       if (!data || !data.attributes || !data.attributes.course || !data.attributes.course.data) {
@@ -598,13 +598,17 @@ module.exports = class AssessmentService extends Schmervice.Service {
         return [null, null, 'This slug is not associated with the specified course and has no assessments.'];
       }
 
-      const slugAssessmentData = data.attributes.assessments && data.attributes.assessments.data;
+      let slugAssessmentData = data.attributes.assessments && data.attributes.assessments.data;
 
       if (!slugAssessmentData) {
         logger.error('No assessments found for this slug.');
         return [null, null, 'No assessments found for this slug.'];
       }
 
+      if (slugAssessmentData.length === 0) {
+        slugAssessmentData = data.attributes.prequizs && data.attributes.prequizs.data;
+      }
+      
       let correct_array;
       let incorrect_array;
       let flag = false;

--- a/lib/services/assessment.js
+++ b/lib/services/assessment.js
@@ -585,45 +585,51 @@ module.exports = class AssessmentService extends Schmervice.Service {
       const { data } = await strapi.findOne('slugs', slug_id, {
         populate: ['course', 'assessments', 'assessments.option', 'prequizs', 'prequizs.option'],
       });
-
-      if (!data || !data.attributes || !data.attributes.course || !data.attributes.course.data) {
-        logger.error('Invalid data structure for the slug.');
-        return [null, null, 'Invalid data structure for the slug.'];
+  
+      if (!data?.attributes?.course?.data?.id) {
+        const errorMsg = 'Invalid data structure for the slug.';
+        logger.error(errorMsg);
+        return [null, null, errorMsg];
       }
-
+  
       const courseId = data.attributes.course.data.id;
-
+  
       if (courseId !== course_id) {
-        logger.error('This slug is not associated with the specified course and has no assessments.');
-        return [null, null, 'This slug is not associated with the specified course and has no assessments.'];
+        const errorMsg = 'This slug is not associated with the specified course and has no assessments.';
+        logger.error(errorMsg);
+        return [null, null, errorMsg];
       }
-
-      let slugAssessmentData = data.attributes.assessments?.data.length
+  
+      const slugAssessmentData = data.attributes.assessments?.data?.length
         ? data.attributes.assessments.data
         : data.attributes.prequizs?.data;
-
+  
       if (!slugAssessmentData) {
-        logger.error('No assessments found for this slug.');
-        return [null, null, 'No assessments found for this slug.'];
+        const errorMsg = 'No assessments found for this slug.';
+        logger.error(errorMsg);
+        return [null, null, errorMsg];
       }
-
-      let correct_array;
-      let incorrect_array;
+  
+      let correct_array = [];
+      let incorrect_array = [];
       let flag = false;
-
-      const assessment = assessmentConverterV2(slugAssessmentData[0].attributes);
-      for (let solu = 0; solu < assessment.length; solu++) {
-        if (assessment[solu].component === 'solution') {
-          correct_array = assessment[solu].correct_options_value.map(obj => obj.value);
-          incorrect_array = assessment[solu].incorrect_options_value.map(obj => obj.value);
+  
+      const assessment = assessmentConverterV2(slugAssessmentData[0]?.attributes);
+      assessment.forEach((item) => {
+        if (item.component === 'solution') {
+          correct_array = item.correct_options_value.map((obj) => obj.value);
+          incorrect_array = item.incorrect_options_value.map((obj) => obj.value);
         }
-      }
+      });
+  
       return [correct_array, incorrect_array, flag];
     } catch (err) {
-      logger.error(`Error validating slug: ${JSON.stringify(err)}`);
+      const errorMsg = `Error validating slug: ${JSON.stringify(err)}`;
+      logger.error(errorMsg);
       return [null, null, false];
     }
   }
+  
 
 
   async markAssessmentCompleteBYSlug(detailsArray, txn) {

--- a/lib/services/assessment.js
+++ b/lib/services/assessment.js
@@ -598,17 +598,15 @@ module.exports = class AssessmentService extends Schmervice.Service {
         return [null, null, 'This slug is not associated with the specified course and has no assessments.'];
       }
 
-      let slugAssessmentData = data.attributes.assessments && data.attributes.assessments.data;
+      let slugAssessmentData = data.attributes.assessments?.data.length
+        ? data.attributes.assessments.data
+        : data.attributes.prequizs?.data;
 
       if (!slugAssessmentData) {
         logger.error('No assessments found for this slug.');
         return [null, null, 'No assessments found for this slug.'];
       }
 
-      if (slugAssessmentData.length === 0) {
-        slugAssessmentData = data.attributes.prequizs && data.attributes.prequizs.data;
-      }
-      
       let correct_array;
       let incorrect_array;
       let flag = false;


### PR DESCRIPTION
Previously, the API only allowed the insertion of the assessment's slug_id into the database, which resulted in an error when attempting to insert the pre-quiz slug_id. This issue has now been resolved, and both the assessment and pre-quiz slug_ids can be successfully inserted without any errors